### PR TITLE
#2 issues for glyphs nil at lower levels.

### DIFF
--- a/FaceMelter_core.lua
+++ b/FaceMelter_core.lua
@@ -161,6 +161,9 @@ function FM_CORE:UnsetGlow(spell_id)
 end
 
 function FM_CORE:PushButtonState()
+    if not self.ActionButtons then
+        return
+    end
     for _, spell in pairs(fm_libs[player_information:GetClass()]:GetSpells()) do
         if not self.ActionButtons[spell.spell_id] then
 
@@ -184,10 +187,15 @@ function FM_CORE:PushButtonState()
 end
 
 function FM_CORE:ClearAllButtons()
+    if not self.textures then
+        return
+    end
     for _, spell in pairs(fm_libs[player_information:GetClass()]:GetSpells()) do
-        self.textures[spell.spell_id]:SetAllPoints()
-        self.textures[spell.spell_id]:SetDesaturation(.9)
-        self:UnsetGlow(spell.spell_id)
+        if spell ~= nil and spell.spell_id ~= nil and self.textures[spell.spell_id] ~= nil then
+            self.textures[spell.spell_id]:SetAllPoints()
+            self.textures[spell.spell_id]:SetDesaturation(.9)
+            self:UnsetGlow(spell.spell_id)
+        end
     end
 end
 

--- a/FaceMelter_core_player.lua
+++ b/FaceMelter_core_player.lua
@@ -164,7 +164,8 @@ function player_prototype:UpdatePlayerGlyphs()
 
     for i=1,NUM_GLYPH_SLOTS  do
         local enabled, glyphType, glyphTooltipIndex, glyphSpellID, icon = GetGlyph(i)
-        if enabled then
+        -- issue #2, player glyph for player at 22 reported as nil
+        if enabled and glyphSpellID ~= nil then
             logger:log_debug("glyph_id: ", glyphSpellID, "idx: ", glyphTooltipIndex)
             logger:log_debug(GetGlyphLink(i))
             self.known_glyphs[glyphSpellID] = glyphTooltipIndex


### PR DESCRIPTION
Fixing issues that looks like are cause by glyph reads at lower level.  Didn't want to remove glyph reads as they are important for some class rotations going forward.